### PR TITLE
Bugfix/pm64 10 sprites error pokemon silver

### DIFF
--- a/src/gen2/Gen2IconDecoder.cpp
+++ b/src/gen2/Gen2IconDecoder.cpp
@@ -12,7 +12,7 @@ Gen2IconDecoder::Gen2IconDecoder(IRomReader& romReader, Gen2GameType gameType)
 
 uint8_t* Gen2IconDecoder::decode(Gen2PokemonIconType iconType, bool firstFrame)
 {
-    uint32_t romOffset = (gameType_ == Gen2GameType::CRYSTAL) ? 0x8EBBF : 0x8EA70;
+    uint32_t romOffset;
     const uint8_t MAX_NUM_TILES = 4;
     const uint8_t TILE_WIDTH = 8;
     const uint8_t TILE_HEIGHT = 8;

--- a/src/gen2/Gen2IconDecoder.cpp
+++ b/src/gen2/Gen2IconDecoder.cpp
@@ -12,7 +12,7 @@ Gen2IconDecoder::Gen2IconDecoder(IRomReader& romReader, Gen2GameType gameType)
 
 uint8_t* Gen2IconDecoder::decode(Gen2PokemonIconType iconType, bool firstFrame)
 {
-    const uint32_t romOffset = (gameType_ == Gen2GameType::CRYSTAL) ? 0x8EBBF : 0x8EA70;
+    uint32_t romOffset = (gameType_ == Gen2GameType::CRYSTAL) ? 0x8EBBF : 0x8EA70;
     const uint8_t MAX_NUM_TILES = 4;
     const uint8_t TILE_WIDTH = 8;
     const uint8_t TILE_HEIGHT = 8;
@@ -23,6 +23,21 @@ uint8_t* Gen2IconDecoder::decode(Gen2PokemonIconType iconType, bool firstFrame)
     uint8_t iconSrcBuffer[MAX_NUM_TILES * BYTES_PER_TILE];
     const uint8_t bankIndex = 0x23;
     uint16_t pointer;
+
+    switch(gameType_)
+    {
+        case Gen2GameType::GOLD:
+            romOffset = 0x8EA70;
+            break;
+        case Gen2GameType::SILVER:
+            romOffset = 0x8EA56;
+            break;
+        case Gen2GameType::CRYSTAL:
+            romOffset = 0x8EBBF;
+            break;
+        default:
+            return buffer_;
+    }
 
     // read IconPointers table entry
     romReader_.seek(romOffset);


### PR DESCRIPTION
**Problem:**: https://github.com/risingPhil/PokeMe64/issues/10

**Root cause**: For some reason pokémon silver has a different rom offset for the IconPointers table.

**Fix**: use the right rom offset!